### PR TITLE
Add card modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ config :trello,
 - `get_list(list_id, secret)`
 - `get_list!(list_id, secret)`
 
-- `get_list_cards(list_id, secret)`
+- `add_comment_to_card( card_id, comment, secret )`
+- `add_comment_to_card!( card_id, comment, secret )`
 
+- `get_list_cards(list_id, secret)`
 - `get_list_cards!(list_id, secret)`
+
 - `get_member(member_id, secret)`
 - `get_member!(member_id, secret)`

--- a/lib/trello.ex
+++ b/lib/trello.ex
@@ -44,8 +44,8 @@ defmodule Trello do
   def get_list(list_id, secret), do: get "/lists/#{list_id}", secret
   def get_list!(list_id, secret), do: get! "/lists/#{list_id}", secret
 
-  def add_comment_to_card( card_id, comment, secret ), do: post "/cards/#{card_id}/actions/comments", %{text: comment} |> Poison.encode!, secret
-  def add_comment_to_card!( card_id, comment, secret ), do: post! "/cards/#{card_id}/actions/comments", %{text: comment} |> Poison.encode!, secret
+  def add_comment_to_card( card_id, comment, secret ), do: post "/cards/#{card_id}/actions/comments", %{text: comment}, secret
+  def add_comment_to_card!( card_id, comment, secret ), do: post! "/cards/#{card_id}/actions/comments", %{text: comment}, secret
   
   def get_list_cards(list_id, secret), do: get "/lists/#{list_id}/cards", secret
   def get_list_cards!(list_id, secret), do: get! "/lists/#{list_id}/cards", secret

--- a/lib/trello.ex
+++ b/lib/trello.ex
@@ -43,6 +43,9 @@ defmodule Trello do
 
   def get_list(list_id, secret), do: get "/lists/#{list_id}", secret
   def get_list!(list_id, secret), do: get! "/lists/#{list_id}", secret
+
+  def add_comment_to_card( card_id, comment, secret ), do: post "/cards/#{card_id}/actions/comments", %{text: comment} |> Poison.encode!, secret
+  def add_comment_to_card!( card_id, comment, secret ), do: post! "/cards/#{card_id}/actions/comments", %{text: comment} |> Poison.encode!, secret
   
   def get_list_cards(list_id, secret), do: get "/lists/#{list_id}/cards", secret
   def get_list_cards!(list_id, secret), do: get! "/lists/#{list_id}/cards", secret

--- a/lib/trello.ex
+++ b/lib/trello.ex
@@ -17,8 +17,8 @@ defmodule Trello do
   def get(url, secret), do: Http.get(create_url(url, secret)) |> unwrap_http
   def get!(url, secret), do: Http.get!(create_url(url, secret)) |> unwrap_http
 
-  def post(url, body, secret), do: Http.post(create_url(url, secret), body) |> unwrap_http
-  def post!(url, body, secret), do: Http.post!(create_url(url, secret), body) |> unwrap_http
+  def post(url, body, secret), do: Http.post(create_url(url, secret), body, %{ "Content-Type": "application/json; charset=utf-8"}) |> unwrap_http
+  def post!(url, body, secret), do: Http.post!(create_url(url, secret), body, %{ "Content-Type": "application/json; charset=utf-8"}) |> unwrap_http
 
   def put(url, body, secret), do: Http.put(create_url(url, secret), body) |> unwrap_http
   def put!(url, body, secret), do: Http.put!(create_url(url, secret), body) |> unwrap_http
@@ -43,7 +43,7 @@ defmodule Trello do
 
   def get_list(list_id, secret), do: get "/lists/#{list_id}", secret
   def get_list!(list_id, secret), do: get! "/lists/#{list_id}", secret
-
+  
   def get_list_cards(list_id, secret), do: get "/lists/#{list_id}/cards", secret
   def get_list_cards!(list_id, secret), do: get! "/lists/#{list_id}/cards", secret
 

--- a/lib/trello_http.ex
+++ b/lib/trello_http.ex
@@ -3,7 +3,7 @@ defmodule Trello.Http do
 
   def process_url(url), do: "https://trello.com/1/" <> url
 
-  def process_request_body(body) when do
+  def process_request_body(body)  do
     if (is_map(body)), do: Poison.encode! body, else: body
   end
   

--- a/lib/trello_http.ex
+++ b/lib/trello_http.ex
@@ -3,8 +3,8 @@ defmodule Trello.Http do
 
   def process_url(url), do: "https://trello.com/1/" <> url
 
-  def process_request_body(body) when is_map(body) do
-    Poison.encode! body
+  def process_request_body(body) when do
+    if (is_map(body)), do: Poison.encode! body, else: body
   end
   
   def process_response_body(body) when is_bitstring(body) do

--- a/lib/trello_http.ex
+++ b/lib/trello_http.ex
@@ -3,8 +3,8 @@ defmodule Trello.Http do
 
   def process_url(url), do: "https://trello.com/1/" <> url
 
-  def process_request_body(body)  do
-    if (is_map(body)), do: Poison.encode! body, else: body
+  defp process_request_body(body) do
+    if (is_map(body)), do: Poison.encode!( body ), else: body
   end
   
   def process_response_body(body) when is_bitstring(body) do

--- a/lib/trello_http.ex
+++ b/lib/trello_http.ex
@@ -3,6 +3,10 @@ defmodule Trello.Http do
 
   def process_url(url), do: "https://trello.com/1/" <> url
 
+  def process_request_body(body) when is_map(body) do
+    Poison.encode! body
+  end
+  
   def process_response_body(body) when is_bitstring(body) do
     if (is_json(body)), do: decode_body(body), else: body
   end


### PR DESCRIPTION
I have added in support for adding comments to trello cards (https://developers.trello.com/advanced-reference/card#post-1-cards-card-id-or-shortlink-actions-comments).  I also updated the Trello.post command to set the headers to json by default (as that is what the trello api desires).
